### PR TITLE
Fix broken rendering when sorting duplicate companies

### DIFF
--- a/src/components/CompanyLoader.vue
+++ b/src/components/CompanyLoader.vue
@@ -223,10 +223,10 @@ export default defineComponent({
       for (let i = 0; i < this.crns.length;) {
         const crn = this.crns[i];
         if (crn === '00000000') {
-          loadedCompanies.push(new Company(crn, false));
+          loadedCompanies.push(new Company(i, crn, false));
           this.loadedCompaniesCount++;
         } else {
-          const companyLoadResult = await loadCompany(crn, this.api);
+          const companyLoadResult = await loadCompany(i, crn, this.api);
           if (companyLoadResult.status === 'success') {
             loadedCompanies.push(companyLoadResult.data);
             this.loadedCompaniesCount++;

--- a/src/components/CompanyOutput.vue
+++ b/src/components/CompanyOutput.vue
@@ -99,7 +99,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="company in sortedCompanies" :key="company.crn">
+            <tr v-for="company in sortedCompanies" :key="company.id">
               <td><a :href="company.humanUrl" target="_blank" rel="noopener noreferrer">{{ company.crn }}</a></td>
               <td :title="company.creationDate ? `Date of incorporation: ${company.creationDate}` : undefined">{{ company.name }}</td>
               <td :title="company.cessationDate ? `Date of cessation: ${company.cessationDate}` : undefined">{{ company.status }}</td>

--- a/src/models/Company.ts
+++ b/src/models/Company.ts
@@ -1,6 +1,7 @@
 import { ICompaniesHouseApi } from './CompaniesHouseApi';
 
 export default class Company {
+  id: number;
   crn: string;
   exists: boolean;
   name: string;
@@ -13,7 +14,8 @@ export default class Company {
   humanUrl: string;
   directors: string[] | null;
 
-  constructor(crn: string, exists: boolean, rawData?: any, rawDirectorsData?: any) {
+  constructor(id: number, crn: string, exists: boolean, rawData?: any, rawDirectorsData?: any) {
+    this.id = id;
     this.crn = crn;
     this.exists = exists;
     this.humanUrl = `https://find-and-update.company-information.service.gov.uk/company/${crn}`;
@@ -214,7 +216,7 @@ export async function handleResponse(response: Response): Promise<ReturnType<typ
   }
 }
 
-export async function loadCompany(crn: string, api: ICompaniesHouseApi): Promise<
+export async function loadCompany(id: number, crn: string, api: ICompaniesHouseApi): Promise<
 | { status: 'success', data: Company }
 | { status: 'rate-limit', ratelimitResetEpochSeconds: number }
 | { status: 'error', error: unknown }
@@ -232,7 +234,7 @@ export async function loadCompany(crn: string, api: ICompaniesHouseApi): Promise
     }
 
     const handledResponse = await handleResponse(companyResponse);
-    if (handledResponse === 404) return { status: 'success', data: new Company(crn, false) };
+    if (handledResponse === 404) return { status: 'success', data: new Company(id, crn, false) };
 
     if (handledResponse !== 200) return handledResponse;
 
@@ -255,7 +257,7 @@ export async function loadCompany(crn: string, api: ICompaniesHouseApi): Promise
     if (handledResponse !== 200) return handledResponse;
 
     const companyDirectorsData = await companyDirectorsRsponse.json();
-    return { status: 'success', data: new Company(crn, true, companyData, companyDirectorsData) };
+    return { status: 'success', data: new Company(id, crn, true, companyData, companyDirectorsData) };
   }
 }
 


### PR DESCRIPTION
When the input CRNs contain a duplicate, sorting the output list results in broken rendering. This fixes that issue by assigning each input company a unique ID that can be used as a key.