### PR TITLE
Fix missing or inaccessible x-ratelimit-reset header

### DIFF
--- a/src/models/CompaniesHouseApi.ts
+++ b/src/models/CompaniesHouseApi.ts
@@ -15,8 +15,6 @@ export default class CompaniesHouseApi implements ICompaniesHouseApi {
     const url = `${this.baseUrl}${path}`;
     const headers = this.headers;
     try {
-      // TODO: Fails here on 429
-      // https://forum.aws.chdev.org/t/cors-headers-missing-from-429-response/5209
       return await fetch(url, { method: 'GET', headers });
     } catch (e) {
       console.error('API request failed', e);

--- a/src/models/Company.ts
+++ b/src/models/Company.ts
@@ -197,7 +197,10 @@ export async function handleResponse(response: Response): Promise<ReturnType<typ
       // Rate limit exceeded
       const ratelimitResetHeader = response.headers.get('x-ratelimit-reset');
       if (ratelimitResetHeader === null) {
-        throw new Error('Missing x-ratelimit-reset header');
+        // This can happen if the server doesn't include the header in the response, or if the CORS
+        // Access-Control-Expose-Headers header is missing or does not include x-ratelimit-reset.
+        // Assume that the rate limit is 5 minutes.
+        return { status: 'rate-limit', ratelimitResetEpochSeconds: Math.floor(Date.now() / 1000) + (5 * 60) };
       }
       return { status: 'rate-limit', ratelimitResetEpochSeconds: parseInt(ratelimitResetHeader, 10) };
     }

--- a/src/models/Company.ts
+++ b/src/models/Company.ts
@@ -231,9 +231,7 @@ export async function loadCompany(id: number, crn: string, api: ICompaniesHouseA
     try {
       companyResponse = await api.request(`/company/${crn}`);
     } catch (e) {
-      // FIXME: Until 429 includes CORS headers, assume that any error is a 5m rate limit (see #3)
-      return { status: 'rate-limit', ratelimitResetEpochSeconds: Math.floor(Date.now() / 1000) + (5 * 60) };
-      // return { status: 'error', error: e };
+      return { status: 'error', error: e };
     }
 
     const handledResponse = await handleResponse(companyResponse);
@@ -249,9 +247,7 @@ export async function loadCompany(id: number, crn: string, api: ICompaniesHouseA
     try {
       companyDirectorsRsponse = await api.request(`/company/${crn}/officers?order_by=appointed_on`);
     } catch (e) {
-      // FIXME: Until 429 includes CORS headers, assume that any error is a 5m rate limit (see #3)
-      return { status: 'rate-limit', ratelimitResetEpochSeconds: Math.floor(Date.now() / 1000) + (5 * 60) };
-      // return { status: 'error', error: e };
+      return { status: 'error', error: e };
     }
 
     const handledResponse = await handleResponse(companyDirectorsRsponse);


### PR DESCRIPTION
429 responses now include _some_ CORS headers, so we no longer get an exception because of `Access-Control-Allow-Origin`, however we cannot access the `x-ratelimit-reset` header because they do not allow it with `Access-Control-Expose-Headers`. This PR removes the error handling for the former, and introduces error handling for the latter.